### PR TITLE
Reduced Thread.sleep amounts

### DIFF
--- a/src/test/java/org/jsoup/integration/ConnectIT.java
+++ b/src/test/java/org/jsoup/integration/ConnectIT.java
@@ -42,7 +42,7 @@ public class ConnectIT {
         });
 
         runner.start();
-        Thread.sleep(1000 * 3);
+        Thread.sleep(1500);
         runner.interrupt();
         assertTrue(runner.isInterrupted());
         runner.join();
@@ -69,7 +69,7 @@ public class ConnectIT {
         });
 
         runner.start();
-        Thread.sleep(3 * 1000);
+        Thread.sleep(1250);
         runner.interrupt();
         assertTrue(runner.isInterrupted());
         runner.join();
@@ -96,7 +96,7 @@ public class ConnectIT {
         });
 
         runner.start();
-        Thread.sleep(2 * 1000);
+        // Thread.sleep(2 * 1000);
         runner.interrupt();
         runner.join();
         assertFalse(ioException.get());


### PR DESCRIPTION
Saves 5250ms by reducing/removing occurrences of Thread.sleep in the ConnectIT test class. The only removed Thread.sleep is from `canInterruptThenJoinASpawnedThread`, while the other occurrences of Thread.sleep are reduced rather than removed. All tested `mvn verify` attempts (30+) were successful.